### PR TITLE
Always run lint job on main branch

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   lint:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Remove condition to run lint job only on pull requests